### PR TITLE
16.cpp 與 16_without_SFINAE.cpp 之修正

### DIFF
--- a/codes/16.cpp
+++ b/codes/16.cpp
@@ -1,9 +1,15 @@
 template <typename T>
-constexpr T &test_add_reference(int) noexcept;
+struct type_identity {
+    using type = T;
+};
+
 template <typename T>
-constexpr T test_add_reference(...) noexcept;
+type_identity<T&> test_add_reference(int) noexcept;
+
+template <typename T>
+type_identity<T>  test_add_reference(...) noexcept;
 
 template <typename T>
 struct add_lvalue_reference {
-    using type = decltype(test_add_reference<T>(0));
+    using type = typename decltype(test_add_reference<T>(0))::type;
 };

--- a/codes/16_without_SFINAE.cpp
+++ b/codes/16_without_SFINAE.cpp
@@ -2,15 +2,203 @@ template <typename T>
 struct add_lvalue_reference {
     using type = T &;
 };
+
+// void 型別
 template <>
 struct add_lvalue_reference<void> {
     using type = void;
 };
+template <>
+struct add_lvalue_reference<const void> {
+    using type = const void;
+};
+template <>
+struct add_lvalue_reference<volatile void> {
+    using type = volatile void;
+};
+template <>
+struct add_lvalue_reference<const volatile void> {
+    using type = const volatile void;
+};
+
+// 復雜的函式型別
 template <typename T, typename ...Args>
-struct add_lvalue_reference<T (Args...)> {
-    using type = T (Args...);
+struct add_lvalue_reference<T (Args...) &> {
+    using type = T (Args...) &;
 };
 template <typename T, typename ...Args>
-struct add_lvalue_reference<T (Args..., ...)> {
-    using type = T (Args..., ...);
+struct add_lvalue_reference<T (Args..., ...) &> {
+    using type = T (Args..., ...) &;
 };
+template <typename T, typename ...Args>
+struct add_lvalue_reference<T (Args...) &&> {
+    using type = T (Args...) &&;
+};
+template <typename T, typename ...Args>
+struct add_lvalue_reference<T (Args..., ...) &&> {
+    using type = T (Args..., ...) &&;
+};
+template <typename T, typename ...Args>
+struct add_lvalue_reference<T (Args...) const> {
+    using type = T (Args...) const;
+};
+template <typename T, typename ...Args>
+struct add_lvalue_reference<T (Args..., ...) const> {
+    using type = T (Args..., ...) const;
+};
+template <typename T, typename ...Args>
+struct add_lvalue_reference<T (Args...) const&> {
+    using type = T (Args...) const&;
+};
+template <typename T, typename ...Args>
+struct add_lvalue_reference<T (Args..., ...) const&> {
+    using type = T (Args..., ...) const&;
+};
+template <typename T, typename ...Args>
+struct add_lvalue_reference<T (Args...) const&&> {
+    using type = T (Args...) const&&;
+};
+template <typename T, typename ...Args>
+struct add_lvalue_reference<T (Args..., ...) const&&> {
+    using type = T (Args..., ...) const&&;
+};
+template <typename T, typename ...Args>
+struct add_lvalue_reference<T (Args...) volatile> {
+    using type = T (Args...) volatile;
+};
+template <typename T, typename ...Args>
+struct add_lvalue_reference<T (Args..., ...) volatile> {
+    using type = T (Args..., ...) volatile;
+};
+template <typename T, typename ...Args>
+struct add_lvalue_reference<T (Args...) volatile&> {
+    using type = T (Args...) volatile&;
+};
+template <typename T, typename ...Args>
+struct add_lvalue_reference<T (Args..., ...) volatile&> {
+    using type = T (Args..., ...) volatile&;
+};
+template <typename T, typename ...Args>
+struct add_lvalue_reference<T (Args...) volatile&&> {
+    using type = T (Args...) volatile&&;
+};
+template <typename T, typename ...Args>
+struct add_lvalue_reference<T (Args..., ...) volatile&&> {
+    using type = T (Args..., ...) volatile&&;
+};
+template <typename T, typename ...Args>
+struct add_lvalue_reference<T (Args...) const volatile> {
+    using type = T (Args...) const volatile;
+};
+template <typename T, typename ...Args>
+struct add_lvalue_reference<T (Args..., ...) const volatile> {
+    using type = T (Args..., ...) const volatile;
+};
+template <typename T, typename ...Args>
+struct add_lvalue_reference<T (Args...) const volatile&> {
+    using type = T (Args...) const volatile&;
+};
+template <typename T, typename ...Args>
+struct add_lvalue_reference<T (Args..., ...) const volatile&> {
+    using type = T (Args..., ...) const volatile&;
+};
+template <typename T, typename ...Args>
+struct add_lvalue_reference<T (Args...) const volatile&&> {
+    using type = T (Args...) const volatile&&;
+};
+template <typename T, typename ...Args>
+struct add_lvalue_reference<T (Args..., ...) const volatile&&> {
+    using type = T (Args..., ...) const volatile&&;
+};
+
+// C++17 起 noexcept 可存在於函式型別
+#if (__cplusplus >= 201703L || __cpp_noexcept_function_type >= 201510L)
+template <typename T, typename ...Args>
+struct add_lvalue_reference<T (Args...) & noexcept> {
+    using type = T (Args...) & noexcept;
+};
+template <typename T, typename ...Args>
+struct add_lvalue_reference<T (Args..., ...) & noexcept> {
+    using type = T (Args..., ...) & noexcept;
+};
+template <typename T, typename ...Args>
+struct add_lvalue_reference<T (Args...) && noexcept> {
+    using type = T (Args...) && noexcept;
+};
+template <typename T, typename ...Args>
+struct add_lvalue_reference<T (Args..., ...) && noexcept> {
+    using type = T (Args..., ...) && noexcept;
+};
+template <typename T, typename ...Args>
+struct add_lvalue_reference<T (Args...) const noexcept> {
+    using type = T (Args...) const noexcept;
+};
+template <typename T, typename ...Args>
+struct add_lvalue_reference<T (Args..., ...) const noexcept> {
+    using type = T (Args..., ...) const noexcept;
+};
+template <typename T, typename ...Args>
+struct add_lvalue_reference<T (Args...) const& noexcept> {
+    using type = T (Args...) const& noexcept;
+};
+template <typename T, typename ...Args>
+struct add_lvalue_reference<T (Args..., ...) const& noexcept> {
+    using type = T (Args..., ...) const& noexcept;
+};
+template <typename T, typename ...Args>
+struct add_lvalue_reference<T (Args...) const&& noexcept> {
+    using type = T (Args...) const&& noexcept;
+};
+template <typename T, typename ...Args>
+struct add_lvalue_reference<T (Args..., ...) const&& noexcept> {
+    using type = T (Args..., ...) const&& noexcept;
+};
+template <typename T, typename ...Args>
+struct add_lvalue_reference<T (Args...) volatile noexcept> {
+    using type = T (Args...) volatile noexcept;
+};
+template <typename T, typename ...Args>
+struct add_lvalue_reference<T (Args..., ...) volatile noexcept> {
+    using type = T (Args..., ...) volatile noexcept;
+};
+template <typename T, typename ...Args>
+struct add_lvalue_reference<T (Args...) volatile& noexcept> {
+    using type = T (Args...) volatile& noexcept;
+};
+template <typename T, typename ...Args>
+struct add_lvalue_reference<T (Args..., ...) volatile& noexcept> {
+    using type = T (Args..., ...) volatile& noexcept;
+};
+template <typename T, typename ...Args>
+struct add_lvalue_reference<T (Args...) volatile&& noexcept> {
+    using type = T (Args...) volatile&& noexcept;
+};
+template <typename T, typename ...Args>
+struct add_lvalue_reference<T (Args..., ...) volatile&& noexcept> {
+    using type = T (Args..., ...) volatile&& noexcept;
+};
+template <typename T, typename ...Args>
+struct add_lvalue_reference<T (Args...) const volatile noexcept> {
+    using type = T (Args...) const volatile noexcept;
+};
+template <typename T, typename ...Args>
+struct add_lvalue_reference<T (Args..., ...) const volatile noexcept> {
+    using type = T (Args..., ...) const volatile noexcept;
+};
+template <typename T, typename ...Args>
+struct add_lvalue_reference<T (Args...) const volatile& noexcept> {
+    using type = T (Args...) const volatile& noexcept;
+};
+template <typename T, typename ...Args>
+struct add_lvalue_reference<T (Args..., ...) const volatile& noexcept> {
+    using type = T (Args..., ...) const volatile& noexcept;
+};
+template <typename T, typename ...Args>
+struct add_lvalue_reference<T (Args...) const volatile&& noexcept> {
+    using type = T (Args...) const volatile&& noexcept;
+};
+template <typename T, typename ...Args>
+struct add_lvalue_reference<T (Args..., ...) const volatile&& noexcept> {
+    using type = T (Args..., ...) const volatile&& noexcept;
+};
+#endif


### PR DESCRIPTION
16.cpp ：
- 引入了型別標簽 `type_identity<T>` (已進入 C++20 標準庫），針對的是不可返回且不可添加參考之型別（如 `void () const` 之類的有 cv 或參考的函式型別）。此實作類似於本人於 cppreference 所添加之[可能實作](https://en.cppreference.com/w/cpp/types/add_reference)。
- 另一方面去除了 `constexpr` 。理由是（可能）出現 ill-formed, no diagnostic required 之錯誤，見[此](http://eel.is/c++draft/dcl.constexpr#7)。

16_without_SFINAE.cpp ：
- 考慮 `void` 型別之 cv 限定。
- 考慮函式型別之 cv 或參考限定（[導致非常復雜的組合](https://en.cppreference.com/w/cpp/types/is_function)）。需要註意的是無限定之函式型別可添加參考。
- 考慮 C++17 起 `noexcept` 成為函式型之一部分。當前之源碼引入了特性測試巨集，或許不宜在此考察。

（由於本人的習慣遣詞差異，以上說法可能有諸多不準確處，望包涵。）